### PR TITLE
Feature - Enable inspect package `stack()` as acceptable `send_exception` traceback parameter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: python
 
 cache: pip
 
-python: ["2.7", "3.2", "3.3", "3.4", "3.5", "3.6", "pypy"]
+python: ["2.7", "3.4", "3.5", "3.6", "pypy"]
 
 # Workaround to install Python 3.7
 # https://github.com/travis-ci/travis-ci/issues/9815

--- a/README.rst
+++ b/README.rst
@@ -240,6 +240,13 @@ Call this function from within a catch block to send the current exception to Ra
   # Send tags, custom data and an HTTP request object
   httpResult = client.send_exception(tags=[], userCustomData={}, request={})
 
+  # Send custom traceback
+  exception = ValueError("new error")
+  new_stack = inspect.stack()
+  # You can even modify the stack:
+  # new_stack = new_stack.append(...)
+  httpResult = client.send_exception(exc_info=[type(exception), exception, new_stack])
+
 You can pass in **either** of these two exception params:
 
 * :code:`exception` should be a subclass of type Exception. Pass this in if you want to manually transmit an exception object to Raygun.

--- a/python2/raygun4py/raygunmsgs.py
+++ b/python2/raygun4py/raygunmsgs.py
@@ -135,7 +135,10 @@ class RaygunErrorMessage(object):
 
         frames = None
         try:
-            frames = inspect.getinnerframes(exc_traceback)
+            if type(exc_traceback) == list and type(exc_traceback[0]) == tuple and 'frame' in str(type(exc_traceback[0][0])).lower():
+                frames = exc_traceback
+            else:
+                frames = inspect.getinnerframes(exc_traceback)
 
             if frames:
                 for frame in frames:

--- a/python2/tests/test_raygunmsgs.py
+++ b/python2/tests/test_raygunmsgs.py
@@ -165,6 +165,19 @@ class TestRaygunErrorMessage(unittest.TestCase):
 
         inspect.getinnerframes = originalGetinnerframes
 
+    def test_inspect_traceback_parameter(self):
+        should_include_me_too = "i'm local"
+        exception = ValueError("Hey there")
+
+        msg = raygunmsgs.RaygunErrorMessage(type(exception), exception, inspect.stack(), { 'transmitLocalVariables': True })
+        localVars = msg.__dict__['stackTrace'][0]['localVariables']
+
+        self.assertTrue('exception' in localVars)
+        self.assertEqual(exception.message, localVars['exception'])
+        self.assertTrue('should_include_me_too' in localVars)
+        self.assertEqual(should_include_me_too, localVars['should_include_me_too'])
+
+
 def getinnerframes_mock_methodname_none(exception):
     return [(
         'localVar',

--- a/python3/raygun4py/raygunmsgs.py
+++ b/python3/raygun4py/raygunmsgs.py
@@ -135,7 +135,12 @@ class RaygunErrorMessage(object):
         self.stackTrace = []
 
         try:
-            frames = inspect.getinnerframes(exc_traceback)
+            if type(exc_traceback) == list and type(exc_traceback[0]) == tuple and 'frame' in str(type(exc_traceback[0][0])).lower():
+                frames = exc_traceback
+            elif type(exc_traceback) == list and 'frame' in str(type(exc_traceback[0])).lower():
+                frames = exc_traceback
+            else:
+                frames = inspect.getinnerframes(exc_traceback)
 
             if frames:
                 for frame in frames:

--- a/python3/tests/test_raygunmsgs.py
+++ b/python3/tests/test_raygunmsgs.py
@@ -201,6 +201,19 @@ class TestRaygunErrorMessage(unittest.TestCase):
 
         inspect.getinnerframes = original_getinnerframes
 
+    def test_inspect_traceback_parameter(self):
+        should_include_me_too = "i'm local"
+        exception = ValueError("Hey there")
+
+        msg = raygunmsgs.RaygunErrorMessage(type(exception), exception, inspect.stack(), { 'transmitLocalVariables': True })
+        localVars = msg.__dict__['stackTrace'][0]['localVariables']
+
+        self.assertTrue('exception' in localVars)
+        self.assertEqual(str(exception), localVars['exception'])
+        self.assertTrue('should_include_me_too' in localVars)
+        self.assertEqual(should_include_me_too, localVars['should_include_me_too'])
+
+
 def getinnerframes_mock_methodname_none(exception):
     return [(
         'localVar',


### PR DESCRIPTION
As a developer, I want to be able to send my traceback to raygun using something other than a python `traceback` and be able to use something like `inspect.stack()` instead. 

TODO:
- [x] Feature for Python2
- [x] Feature for Python3
- [x] Test coverage